### PR TITLE
Fix fs.lopen in Python 2, to use io module

### DIFF
--- a/src/pyload/utils/fs.py
+++ b/src/pyload/utils/fs.py
@@ -192,7 +192,7 @@ def lopen(filename, mode='r', buffering=-1, encoding='utf-8', errors=None,
         flags = portalocker.LOCK_EX
     else:
         flags = portalocker.LOCK_EX | portalocker.LOCK_NB
-    with open(filename, mode, buffering, encoding,
+    with _open(filename, mode, buffering, encoding,
               errors, newline, closefd) as fp:
         portalocker.lock(fp, flags)
         yield fp


### PR DESCRIPTION
In Python 2, `lopen` is failing when trying to open a file in bynary mode:

```
(Pdb) locals()
{'errors': None, 'inspect': <module 'inspect' from '/usr/lib/python2.7/inspect.pyc'>, 'encoding': None, 'newline': None, 'filename': u'session.ini', 'flags': 6, 'closefd': True, 'buffering': -1, 'blocking': False, 'mode': u'ab+'}
(Pdb) open(filename, mode=mode, buffering=buffering, encoding=encoding, errors=errors, newline=newline, closefd=closefd).__enter__()
*** ValueError: binary mode doesn't take an encoding argument
(Pdb) io.open(filename, mode=mode, buffering=buffering, encoding=encoding, errors=errors, newline=newline, closefd=closefd).__enter__()
<_io.BufferedRandom name=u'session.ini'>
```

As the current `open` context manager already uses the `io.open` function, it seems just like a typo.