### PR TITLE
Create the bitmath object during size conversion

### DIFF
--- a/src/pyload/utils/convert.py
+++ b/src/pyload/utils/convert.py
@@ -53,7 +53,10 @@ def size(value, in_unit, out_unit):
     out_unit += "yte" if out_unit == 'B' else "iB"
 
     try:
-        in_size = getattr(bitmath, in_unit)
+        # Create a bitmath instance representing the input value with its
+        # corresponding unit
+        in_size = getattr(bitmath, in_unit)(value)
+        # Call the instance method to convert it to the output unit
         out_size = getattr(in_size, 'to_' + out_unit)()
         return out_size.value
 


### PR DESCRIPTION
Existing code was not initializing the `bitmath` object with the desired value. Because there was no instance, trying to call an instance method failed.

Related stacktrace:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "build/bdist.linux-x86_64/egg/pyload/core/init.py", line 461, in run
    self._init_config()
  File "build/bdist.linux-x86_64/egg/pyload/core/init.py", line 328, in _init_config
    session = ConfigParser(self.__SESSIONFILENAME, session_defaults)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 247, in __init__
    ConfigSection.__init__(self, self, config)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 140, in __init__
    self.update(config or ())
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 162, in update
    for name, value in iterable
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 149, in _to_configentry
    entry_obj = func(self.parser, *entry_args)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 140, in __init__
    self.update(config or ())
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 162, in update
    for name, value in iterable
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 149, in _to_configentry
    entry_obj = func(self.parser, *entry_args)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 73, in __init__
    self._set_value(value)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 89, in _set_value
    self.value = self.default = self._normalize_value(value)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 103, in _normalize_value
    return self._convert_map[self.type](value)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 51, in <lambda>
    InputType.Size: lambda x: 0 if x is None else parse.bytesize(x),
  File "build/bdist.linux-x86_64/egg/pyload/utils/parse.py", line 124, in bytesize
    return convert.size(size, unit, 'byte')
  File "build/bdist.linux-x86_64/egg/pyload/utils/convert.py", line 57, in size
    out_size = getattr(in_size, 'to_' + out_unit)()
TypeError: unbound method to_Byte() must be called with MiB instance as first argument (got nothing instead)
```