### PR TITLE
Catch IDNA encoding issue for URI with port

### DIFF
--- a/src/pyload/utils/web/convert.py
+++ b/src/pyload/utils/web/convert.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 def splitaddress(address):
     try:
         address = idna.encode(address)
-    except AttributeError:
+    except (AttributeError, idna.IDNAError):
         pass
     sep = ']:' if address.split(':', 2)[2:] else ':'
     parts = address.rsplit(sep, 1)


### PR DESCRIPTION
`idna.encode` fails with a `IDNAError` exception when the specified URI includes a port definition. Ignoring it makes current code to parse values like `localhost:514`.

Related stacktrace:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "build/bdist.linux-x86_64/egg/pyload/core/init.py", line 461, in run
    self._init_config()
  File "build/bdist.linux-x86_64/egg/pyload/core/init.py", line 328, in _init_config
    session = ConfigParser(self.__SESSIONFILENAME, session_defaults)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 243, in __init__
    ConfigSection.__init__(self, self, config)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 136, in __init__
    self.update(config or ())
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 158, in update
    for name, value in iterable
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 145, in _to_configentry
    entry_obj = func(self.parser, *entry_args)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 136, in __init__
    self.update(config or ())
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 158, in update
    for name, value in iterable
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 145, in _to_configentry
    entry_obj = func(self.parser, *entry_args)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 73, in __init__
    self._set_value(value)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 89, in _set_value
    self.value = self.default = self._normalize_value(value)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 99, in _normalize_value
    return self._convert_map[self.type](value)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 54, in <lambda>
    endpoint if isendpoint(x) else socket)(x),
  File "build/bdist.linux-x86_64/egg/pyload/utils/web/check.py", line 66, in isendpoint
    host, port = splitaddress(value)
  File "build/bdist.linux-x86_64/egg/pyload/utils/web/convert.py", line 17, in splitaddress
    address = idna.encode(address)
  File "$HOME/.virtualenvs/pyload2/local/lib/python2.7/site-packages/idna/core.py", line 355, in encode
    result.append(alabel(label))
  File "$HOME/.virtualenvs/pyload2/local/lib/python2.7/site-packages/idna/core.py", line 265, in alabel
    raise IDNAError('The label {0} is not a valid A-label'.format(label))
IDNAError: The label localhost:514 is not a valid A-label
```