### PR TITLE
Fix makefile when file exists in current directory

### DIFF
--- a/src/pyload/utils/fs.py
+++ b/src/pyload/utils/fs.py
@@ -246,10 +246,10 @@ def makedirs(dirname, mode=0o777, exist_ok=False):
 
 
 def makefile(filepath, mode=0o700, size=None, exist_ok=False):
-    dirname, filename = os.path.split(filepath)
+    dirname, _ = os.path.split(filepath)
     makedirs(dirname, mode, exist_ok=True)
     try:
-        mkfile(filename, size)
+        mkfile(filepath, size)
     except OSError as e:
         if not os.path.isfile(filepath) or not exist_ok:
             raise OSError(e)


### PR DESCRIPTION
`fs.makefile` was checking the path for the file to create exists, and then it tried to create the file. However, it tried to create it by using just the file name, instead of the absolute path to the file. For this reason, if a file with that name already existed in the pyload directory, if failed and the file was not being created.

Relevant log lines:
```
2017-07-27 20:07:09  CRITICAL  Path already exists
```