### PR TITLE
 Add default value for ioclass parameter

### DIFF
--- a/src/pyload/utils/system.py
+++ b/src/pyload/utils/system.py
@@ -151,7 +151,7 @@ def renice(pid=None, niceness=None):
     psp.nice(value)
 
 
-def ionice(pid=None, ioclass=None, niceness=None):
+def ionice(pid=None, ioclass=psutil.IOPRIO_CLASS_IDLE, niceness=None):
     """
     Unix notation process I/O nicener.
     """


### PR DESCRIPTION
The `ionice` function from `psutil` expects an ioclass to set its priority:
https://pythonhosted.org/psutil/_modules/psutil.html#Process.ionice

However, it was being called without `ioclass` specified, which was failing on Linux (and probably explodes on Windows because of the `[ioclass]` indexing notation).

I arbitrarily used the `IDLE` class, but it could be changed to any valid ioclass:
https://pythonhosted.org/psutil/#psutil.IOPRIO_CLASS_NONE

Relevant error:
```
CRITICAL  'ioclass' argument must be specified
```