### PR TITLE
Change parse.bytesize to return integer values

### DIFF
--- a/src/pyload/utils/parse.py
+++ b/src/pyload/utils/parse.py
@@ -111,7 +111,7 @@ _RE_SIZE = re.compile(r'(?P<S>[\d.,]+)\s*(?P<U>[a-zA-Z]*)')
 def bytesize(text, unit=None):  # returns integer bytes
     DEFAULT_INPUTUNIT = 'byte'
 
-    m = _RE_SIZE.match(text)
+    m = _RE_SIZE.match(str(text))
     if m is None:
         return None
 
@@ -121,7 +121,7 @@ def bytesize(text, unit=None):  # returns integer bytes
     size = float(m.group('S').replace(',', '.'))
     unit = unit[0].lower()
 
-    return convert.size(size, unit, 'byte')
+    return int(convert.size(size, unit, 'byte'))
 
 
 _TIMEWORDS = ("this", "a", "an", "next")


### PR DESCRIPTION
`parse.bytesize` is responsible for translating config size values to bytes. However, it's currently returning floating point values, which are not supported in bitwise shift operations, like `<<` that is being used to convert this value to KiB or MiB accross the core codebase.

This change fixes it by returning integer byte values, and also by accepting non-string values as input.

Relevant log error:
```
CRITICAL  unsupported operand type(s) for <<: 'float' and 'int'
```